### PR TITLE
Raspotify .service upgrade fix

### DIFF
--- a/etc/shairport-sync.conf
+++ b/etc/shairport-sync.conf
@@ -101,7 +101,7 @@ pa =
 pipe =
 {
 //	name = "/path/to/pipe"; // there is no default pipe name for the output
-	name = "/tmp/snapfifo_shairport";
+	name = "/run/snapserver/snapfifo_shairport";
 };
 
 // These are no configuration file parameters for the "stdout" audio back end. No interpolation is done.

--- a/etc/snapserver.conf
+++ b/etc/snapserver.conf
@@ -129,11 +129,11 @@ bind_to_address = ::
 # tcp server: tcp://<listen IP, e.g. 127.0.0.1>:<port>?name=<name>[&mode=server]
 # tcp client: tcp://<server IP, e.g. 127.0.0.1>:<port>?name=<name>&mode=client
 # spotify pipe stream
-source = pipe:///tmp/snapfifo_raspotify?name=Spotify&codec=null&sampleformat=44100:16:2
+source = pipe:///run/snapserver/snapfifo_raspotify?name=Spotify&codec=null&sampleformat=44100:16:2
 # airplay pipe stream
-source = pipe:///tmp/snapfifo_shairport?name=Airplay&codec=null&sampleformat=44100:16:2
+source = pipe:///run/snapserver/snapfifo_shairport?name=Airplay&codec=null&sampleformat=44100:16:2
 # bluetooth pipe stream
-source = pipe:///tmp/snapfifo_bluetooth?name=Bluetooth&codec=null&sampleformat=44100:16:2
+source = pipe:///run/snapserver/snapfifo_bluetooth?name=Bluetooth&codec=null&sampleformat=44100:16:2
 # client bluetooth tcp stream
 source = tcp://0.0.0.0:4953?name=ClientBluetooth&mode=server&codec=null&sampleformat=44100:16:2
 # global music stream

--- a/serverInstall.sh
+++ b/serverInstall.sh
@@ -126,17 +126,6 @@ echo -e "\n${LIGHT_BLUE}configuring snapserver...${NC}"
 sudo cp ./etc/snapserver.conf /etc/snapserver.conf
 sed -i '/\[Service\]/a RuntimeDirectory=snapserver' /lib/systemd/system/snapserver.service
 
-# old way to configure (and with multiple streams)
-#sudo sed -i "0,/^stream.*/s//first_mark_point_stream/" /etc/snapserver.conf
-#sudo sed -i "s/^stream.*//g" /etc/snapserver.conf
-
-#sudo sed -i "s/^first_mark_point_stream/# raspotify pipe stream\\n# shairport pipe stream/g" /etc/snapserver.conf
-
-#value="stream = pipe:///tmp/snapfifo?name=Spotify&sampleformat=44100:16:2"
-#sudo sed -i  "/# raspotify pipe stream/a ${value}" /etc/snapserver.conf
-#value="stream = pipe:///tmp/snapfifo_shairport?name=ShairportSync&sampleformat=44100:16:2"
-#sudo sed -i  "/# shairport pipe stream/a ${value}" /etc/snapserver.conf
-
 
 echo -e "\n${CYAN}restarting raspotify, shairport-sync and snapcast services${NC}"
 if $INSTALL_RASPOTIFY; then sudo systemctl restart raspotify.service; fi

--- a/serverInstall.sh
+++ b/serverInstall.sh
@@ -58,14 +58,14 @@ done
 
 # raspotify setup
 if $INSTALL_RASPOTIFY; then
-  OPTIONS_VALUE="--device /tmp/snapfifo_raspotify"
+  OPTIONS_VALUE="--device /run/snapserver/snapfifo_raspotify"
   BACKEND_ARGS_VALUE="--backend pipe"
 
   RASPOTIFY_FILE="/etc/default/raspotify"
 
   echo -e "\n${GREEN}installing raspotify...${NC}"
 
-  curl -k -L https://github.com/dtcooper/raspotify/releases/download/0.16.0/raspotify_0.16.0.librespot.v0.1.3-37-g0adb851_armhf.deb -o 'raspotify.deb' &&
+  curl -k -L https://github.com/dtcooper/raspotify/releases/download/0.31.3/raspotify_0.31.3.librespot.v0.3.1-19-gbbd575e_armhf.deb -o 'raspotify.deb' &&
   sudo apt install ./raspotify.deb -y
   rm -f raspotify.deb
 
@@ -81,9 +81,10 @@ fi
 
 # shairport setup
 if $INSTALL_SHAIRPORT; then
+  SHAIRPORT_VERSION="3.3.8"
   echo -e "\n${YELLOW}building shairport-sync...${NC}"
-  curl -sL https://github.com/mikebrady/shairport-sync/archive/3.3.7rc2.tar.gz | tar xz
-  cd shairport-sync-3.3.7rc2/
+  curl -sL https://github.com/mikebrady/shairport-sync/archive/$SHAIRPORT_VERSION.tar.gz | tar xz
+  cd shairport-sync-$SHAIRPORT_VERSION/
   autoreconf -i -f
   ./configure 'CFLAGS=-O3' 'CXXFLAGS=-O3' --sysconfdir=/etc --with-pipe --with-systemd --with-avahi --with-ssl=openssl
   make
@@ -91,7 +92,7 @@ if $INSTALL_SHAIRPORT; then
   echo -e "\n${GREEN}installing shairport-sync...${NC}"
   sudo make install
   cd ..
-  rm -r shairport-sync-3.3.7rc2/
+  rm -r shairport-sync-$SHAIRPORT_VERSION/
   sudo systemctl enable shairport-sync
 
   echo -e "\n${LIGHT_BLUE}configuring shairport-sync...${NC}"
@@ -102,8 +103,9 @@ fi
 # bluetooth setup
 if $INSTALL_BLUETOOTH; then
   if ! command -v bluealsa &> /dev/null; then
-    echo -e "\n{RED}bluealsa could not be found${NC}"
-    echo -e "{LIGHT_GRAY}skipping bluetooth instalation${NC}"
+    echo -e "\n${RED}bluealsa could not be found${NC}"
+    echo -e "${LIGHT_GRAY}skipping bluetooth instalation${NC}"
+    INSTALL_BLUETOOTH=false
   else
     echo -e "\n${LIGHT_BLUE}configuring BlueAlsa...${NC}"
     bash ./scripts/config-bluetooth.sh "$DEVICE_NAME"
@@ -114,7 +116,6 @@ if $INSTALL_BLUETOOTH; then
 fi
 
 # snapserver setup
-
 echo -e "\n${GREEN}installing snapcast server...${NC}"
 curl -k -L https://github.com/badaix/snapcast/releases/download/v0.25.0/snapserver_0.25.0-1_armhf.deb -o 'snapserver.deb' &&
 sudo apt install ./snapserver.deb -y
@@ -123,6 +124,7 @@ rm -f snapserver.deb
 
 echo -e "\n${LIGHT_BLUE}configuring snapserver...${NC}"
 sudo cp ./etc/snapserver.conf /etc/snapserver.conf
+sed -i '/\[Service\]/a RuntimeDirectory=snapserver' /lib/systemd/system/snapserver.service
 
 # old way to configure (and with multiple streams)
 #sudo sed -i "0,/^stream.*/s//first_mark_point_stream/" /etc/snapserver.conf
@@ -140,4 +142,5 @@ echo -e "\n${CYAN}restarting raspotify, shairport-sync and snapcast services${NC
 if $INSTALL_RASPOTIFY; then sudo systemctl restart raspotify.service; fi
 if $INSTALL_SHAIRPORT; then sudo systemctl restart shairport-sync.service; fi
 if $INSTALL_BLUETOOTH; then sudo systemctl restart bluealsa.service bluealsa-aplay.service; fi
+sudo systemctl daemon-reload
 sudo systemctl restart snapserver.service

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -56,16 +56,17 @@ else
 fi
 
 if command -v shairport-sync &> /dev/null; then
+	SHAIRPORT_VERSION="3.3.8"
 	echo -e "\n${YELLOW}removing ${LIGHT_BLUE}shairport${NC}"
 	echo -e "\n${WHITE}building ${LIGHT_BLUE}shairport${WHITE} makefile${NC}"
-	curl -sL https://github.com/mikebrady/shairport-sync/archive/3.3.7rc2.tar.gz | tar xz
-	cd shairport-sync-3.3.7rc2/
+	curl -sL https://github.com/mikebrady/shairport-sync/archive/$SHAIRPORT_VERSION.tar.gz | tar xz
+	cd shairport-sync-$SHAIRPORT_VERSION/
 	autoreconf -i -f
 	./configure --sysconfdir=/etc --with-pipe --with-systemd --with-avahi --with-ssl=openssl
-	
+
 	echo -e "\n${YELLOW}runing make uninstall for ${LIGHT_BLUE}shairport${NC}"
 	sudo make uninstall
-	rm -r shairport-sync-3.3.7rc2/
+	rm -r shairport-sync-$SHAIRPORT_VERSION/
 
 	echo -e "\n${YELLOW}cleaning ${LIGHT_BLUE}shairport${YELLOW}configuration files${NC}"
 	sudo systemctl stop shairport-sync.service


### PR DESCRIPTION
After raspotify package got updated, its `systemctl` service file became more picky in security (see [this commit](https://github.com/dtcooper/raspotify/commit/a844a33428018cae34e4c9642aaaca5964ae8502)) and broke the pipe backend with snapserver (see [this comment](https://github.com/dtcooper/raspotify/issues/468#issuecomment-982272317) about raspotify not having access to `/tmp/`).

The fix was to move the pipe fifo to `/var/run/` (or `/run/`, which is the same).

So this PR:
 - changes the pipe locations from `/tmp/` to `/run/snapserver`
 - add `RuntimeDirectory=snapserver` to `snapserver.service`, so that **_systemd_** manages the creation of `/run/snapserver`.
 - clean some script instalation code
